### PR TITLE
Event 탭 시간 표시 문제 해결

### DIFF
--- a/themes/openinfrakr/layouts/events/list.html
+++ b/themes/openinfrakr/layouts/events/list.html
@@ -76,7 +76,7 @@
                             <div class="event-content">
                                 <h2 class="event-title">{{ .Title }}</h2>
                                 <div class="event-date">
-                                    {{ dateFormat "2006.01.02 15:04" .Date }} (UTC+GMT +9)
+                                    {{ dateFormat "2006.01.02 15:04" .Date }} (UTC+9)
                                 </div>
                                 {{ if .Params.location }}
                                 <div class="event-location">


### PR DESCRIPTION
Event 탭에서 현재 진행중 이벤트 정상적으로 표시 안되는 문재 해결
시간 표시가 이상했던 기존 commit 변경